### PR TITLE
Fix spelling mistakes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3125,7 +3125,7 @@ No changes.
 
 ### Removed (1 change)
 
-- repository: Remove harmful `name` paramater in FetchRemote. !3227
+ - repository: Remove harmful `name` parameter in FetchRemote. !3227
 
 ### Fixed (13 changes)
 
@@ -5761,7 +5761,7 @@ Should not be used as it [will break gitlab-rails](https://gitlab.com/gitlab-org
 #### Other
 - Initial design document for High Availability
   https://gitlab.com/gitlab-org/gitaly/merge_requests/1058
-- Reverse proxy pass thru for HA
+- Reverse proxy pass through for HA
   https://gitlab.com/gitlab-org/gitaly/merge_requests/1064
 
 ## v1.19.1

--- a/_support/generate-praefect-schema
+++ b/_support/generate-praefect-schema
@@ -74,7 +74,7 @@ EOF
 
 # And then finally dump the database schema. We ignore the owner because it
 # would change based on the local user name. Furthermore, we replace the
-# database version such that the output doesn't change based on the the
+# database version such that the output doesn't change based on the
 # Postgres version.
 pg_dump --create --schema-only --no-owner --dbname "$DBNAME" |
     sed -e 's/^\(-- Dumped .* version\) [0-9]\+\(.[0-9]\+\).*/\1 REPLACED/'

--- a/doc/PROCESS.md
+++ b/doc/PROCESS.md
@@ -682,7 +682,7 @@ Slack channel.
 
 Sometimes, we need to work on both Gitaly and GitLab Rails implementations in parallel. Ideally, we can define and
 publish all Protobuf changes beforehand. In practice, a complicated change might require modifying the Protobuf multiple
-times until reaching a stable state. It's more convenient to let GitLab Rails point the gem to the the developing branch
+times until reaching a stable state. It's more convenient to let GitLab Rails point the gem to the developing branch
 in Gitaly.
 
 In the local environment, we can point it to the developing gem using following steps:

--- a/internal/cli/praefect/subcmd_verify.go
+++ b/internal/cli/praefect/subcmd_verify.go
@@ -45,7 +45,7 @@ Examples:
 			},
 			&cli.StringFlag{
 				Name:  "storage",
-				Usage: "name of the the physical storage associated with the virtual storage with replicas to mark as unverified",
+				Usage: "name of the physical storage associated with the virtual storage with replicas to mark as unverified",
 			},
 		},
 		Before: func(ctx *cli.Context) error {

--- a/internal/gitaly/service/repository/size_test.go
+++ b/internal/gitaly/service/repository/size_test.go
@@ -250,7 +250,7 @@ func TestGetObjectDirectorySize_quarantine(t *testing.T) {
 		quarantine2, err := quarantine.New(ctx, gittest.RewrittenRepository(t, ctx, cfg, repo2), logger, locator)
 		require.NoError(t, err)
 
-		// We swap out the the object directories of both quarantines. So while both are
+		// We swap out the object directories of both quarantines. So while both are
 		// valid, we still expect that this RPC call fails because we detect that the
 		// swapped-in quarantine directory does not belong to our repository.
 		repo := proto.Clone(quarantine1.QuarantinedRepo()).(*gitalypb.Repository)

--- a/internal/gitaly/storage/storagemgr/middleware_ext_test.go
+++ b/internal/gitaly/storage/storagemgr/middleware_ext_test.go
@@ -85,7 +85,7 @@ func TestMiddleware_partitioning_hint(t *testing.T) {
 						Repository: fork,
 						// We're using different source repository than the object pool we'll link to at the end of the test.
 						// The linking would fail at the end if the repository was partitioned implicitly with the source repository
-						// instead of the the explicitly hinted repository.
+						// instead of the explicitly hinted repository.
 						SourceRepository: sourceRepository,
 					})
 				require.NoError(t, err)

--- a/internal/gitaly/storage/wal/entry.go
+++ b/internal/gitaly/storage/wal/entry.go
@@ -289,7 +289,7 @@ func (e *Entry) RecordAlternateUnlink(storageRoot, relativePath, alternatePath s
 // existence in the pre-image.
 //
 // While going through the reference changes, we'll build two tree representations of the references being updated
-// The first tree consists of operations that create a file, namely refererence updates and creations. The second
+// The first tree consists of operations that create a file, namely reference updates and creations. The second
 // tree consists of operations that may delete files, so reference deletions.
 //
 // With the pre-image state built, the reference changes are applied to the repository. We then figure out the

--- a/internal/praefect/replicator.go
+++ b/internal/praefect/replicator.go
@@ -563,7 +563,7 @@ func (r ReplMgr) backfillReplicaPath(ctx context.Context, event datastore.Replic
 		fallthrough
 	// 14.5 also doesn't schedule DeleteRepo jobs. Any jobs are again old jobs in-flight.
 	// The repository ID in delete jobs scheduled in 14.4 won't be present anymore at the time the
-	// replication job is being executed, as the the 'repositories' record is deleted. Given that,
+	// replication job is being executed, as the 'repositories' record is deleted. Given that,
 	// it's not possible to get the replica path. In 14.4, Praefect intercepts deletes and handles
 	// them without scheduling replication jobs. The 'delete' jobs still in flight are handled as before
 	// for backwards compatibility.

--- a/proto/commit.proto
+++ b/proto/commit.proto
@@ -469,7 +469,7 @@ message GetTreeEntriesRequest {
   bytes revision = 2;
   // path is the path of the entry that shall be read, relative to the tree of the specified revision.
   bytes path = 3;
-  // recursive denotes wether to recursively fetch sub-trees.
+  // recursive denotes whether to recursively fetch sub-trees.
   bool recursive = 4;
   // sort defines the sorting parameter.
   SortBy sort = 5;

--- a/proto/diff.proto
+++ b/proto/diff.proto
@@ -459,7 +459,7 @@ message RangePair {
 message RevisionRange {
   // rev1 is the first revision.
   string rev1 = 1;
-  // rev2 is the the second revision.
+  // rev2 is the second revision.
   string rev2 = 2;
 }
 
@@ -469,7 +469,7 @@ message BaseWithRevisions {
   string base = 1;
   // rev1 is the first revision.
   string rev1 = 2;
-  // rev2 is the the second revision.
+  // rev2 is the second revision.
   string rev2 = 3;
 }
 
@@ -487,7 +487,7 @@ message RawRangeDiffRequest {
   }
 }
 
-// RawRangeDiffResponse is the the raw range diff response.
+// RawRangeDiffResponse is the raw range diff response.
 message RawRangeDiffResponse {
   // data is the raw range diff data.
   bytes data = 1;

--- a/proto/go/gitalypb/commit.pb.go
+++ b/proto/go/gitalypb/commit.pb.go
@@ -1557,7 +1557,7 @@ type GetTreeEntriesRequest struct {
 	Revision []byte `protobuf:"bytes,2,opt,name=revision,proto3" json:"revision,omitempty"`
 	// path is the path of the entry that shall be read, relative to the tree of the specified revision.
 	Path []byte `protobuf:"bytes,3,opt,name=path,proto3" json:"path,omitempty"`
-	// recursive denotes wether to recursively fetch sub-trees.
+       // recursive denotes whether to recursively fetch sub-trees.
 	Recursive bool `protobuf:"varint,4,opt,name=recursive,proto3" json:"recursive,omitempty"`
 	// sort defines the sorting parameter.
 	Sort GetTreeEntriesRequest_SortBy `protobuf:"varint,5,opt,name=sort,proto3,enum=gitaly.GetTreeEntriesRequest_SortBy" json:"sort,omitempty"`

--- a/proto/go/gitalypb/diff.pb.go
+++ b/proto/go/gitalypb/diff.pb.go
@@ -1911,7 +1911,7 @@ type RevisionRange struct {
 
 	// rev1 is the first revision.
 	Rev1 string `protobuf:"bytes,1,opt,name=rev1,proto3" json:"rev1,omitempty"`
-	// rev2 is the the second revision.
+       // rev2 is the second revision.
 	Rev2 string `protobuf:"bytes,2,opt,name=rev2,proto3" json:"rev2,omitempty"`
 }
 
@@ -1971,7 +1971,7 @@ type BaseWithRevisions struct {
 	Base string `protobuf:"bytes,1,opt,name=base,proto3" json:"base,omitempty"`
 	// rev1 is the first revision.
 	Rev1 string `protobuf:"bytes,2,opt,name=rev1,proto3" json:"rev1,omitempty"`
-	// rev2 is the the second revision.
+       // rev2 is the second revision.
 	Rev2 string `protobuf:"bytes,3,opt,name=rev2,proto3" json:"rev2,omitempty"`
 }
 
@@ -2136,7 +2136,7 @@ func (*RawRangeDiffRequest_RevisionRange) isRawRangeDiffRequest_RangeSpec() {}
 
 func (*RawRangeDiffRequest_BaseWithRevisions) isRawRangeDiffRequest_RangeSpec() {}
 
-// RawRangeDiffResponse is the the raw range diff response.
+// RawRangeDiffResponse is the raw range diff response.
 type RawRangeDiffResponse struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache


### PR DESCRIPTION
## Summary
- fix typos in changelog and docs
- correct duplicate words in comments
- update proto comments with correct spelling

## Testing
- `gofmt -w internal/cli/praefect/subcmd_verify.go internal/gitaly/service/repository/size_test.go internal/gitaly/storage/storagemgr/middleware_ext_test.go internal/praefect/replicator.go internal/gitaly/storage/wal/entry.go`
- `git diff --check`
